### PR TITLE
Extended Log Handling

### DIFF
--- a/web_tables.py
+++ b/web_tables.py
@@ -379,7 +379,7 @@ def process_message(_message):
         p = _message[1:].split(",")
         if p[0] == 'GROUP VOICE':
             if p[1] == 'END':
-                log_message = '{}: {} {}:   System: {}; IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}; Duration: {}s'.format(_now, p[0], p[1], p[2], p[4], alias_string(int(p[4]), peer_ids), p[5], alias_string(int(p[5]), subscriber_ids), p[6], p[7], p[8])
+                log_message = '{}: {} {}: System: {}; IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}; Duration: {}s'.format(_now, p[0], p[1], p[2], p[4], alias_string(int(p[4]), peer_ids), p[5], alias_string(int(p[5]), subscriber_ids), p[6], p[7], p[8])
             elif p[1] == 'START':
                 log_message = '{}: {} {}: System: {}; IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}'.format(_now, p[0], p[1], p[2], p[4], alias_string(int(p[4]), peer_ids), p[5], alias_string(int(p[5]), subscriber_ids), p[6], p[7])
             elif p[1] == 'END WITHOUT MATCHING START':
@@ -387,7 +387,24 @@ def process_message(_message):
             else:
                 log_message = '{}: UNKNOWN GROUP VOICE LOG MESSAGE'.format(_now)
         else:
-            log_message = '{}: UNKNOWN LOG MESSAGE'.format(_now)
+            nfo = []
+            for cnt in p:
+                tnfo = cnt.split(":")
+                for cnfo in tnfo:
+                    nfo.append(cnfo.strip())
+            hdr = nfo[0].split(")")
+            hdr[1] = hdr[1].strip()
+
+            if hdr[1] == "GROUP VOICE START":
+                log_message = '{}: {}: System: {}); IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}'.format(_now,hdr[1],hdr[0],nfo[3],alias_string(int(nfo[3]), peer_ids), nfo[5], alias_string(int(nfo[5]), subscriber_ids),nfo[7],nfo[9])
+            elif hdr[1] == "GROUP VOICE END":
+                dur = nfo[9].split(" ")
+                log_message = '{}: {}: System: {}); IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}; Duration: {}'.format(_now,hdr[1],hdr[0],nfo[3],alias_string(int(nfo[3]), peer_ids), nfo[5], alias_string(int(nfo[5]), subscriber_ids),nfo[7],dur[0],nfo[10])
+            else:
+                log_message = '{}: UNKNOWN LOG MESSAGE'.format(_now)
+
+
+            
             
         dashboard_server.broadcast('l' + log_message)
         LOGBUF.append(log_message)

--- a/web_tables.py
+++ b/web_tables.py
@@ -379,7 +379,7 @@ def process_message(_message):
         p = _message[1:].split(",")
         if p[0] == 'GROUP VOICE':
             if p[1] == 'END':
-                log_message = '{}: {} {}: System: {}; IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}; Duration: {}s'.format(_now, p[0], p[1], p[2], p[4], alias_string(int(p[4]), peer_ids), p[5], alias_string(int(p[5]), subscriber_ids), p[6], p[7], p[8])
+                log_message = '{}: {} {}:   System: {}; IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}; Duration: {}s'.format(_now, p[0], p[1], p[2], p[4], alias_string(int(p[4]), peer_ids), p[5], alias_string(int(p[5]), subscriber_ids), p[6], p[7], p[8])
             elif p[1] == 'START':
                 log_message = '{}: {} {}: System: {}; IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}'.format(_now, p[0], p[1], p[2], p[4], alias_string(int(p[4]), peer_ids), p[5], alias_string(int(p[5]), subscriber_ids), p[6], p[7])
             elif p[1] == 'END WITHOUT MATCHING START':
@@ -399,7 +399,7 @@ def process_message(_message):
                 log_message = '{}: {}: System: {}); IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}'.format(_now,hdr[1],hdr[0],nfo[3],alias_string(int(nfo[3]), peer_ids), nfo[5], alias_string(int(nfo[5]), subscriber_ids),nfo[7],nfo[9])
             elif hdr[1] == "GROUP VOICE END":
                 dur = nfo[9].split(" ")
-                log_message = '{}: {}: System: {}); IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}; Duration: {}'.format(_now,hdr[1],hdr[0],nfo[3],alias_string(int(nfo[3]), peer_ids), nfo[5], alias_string(int(nfo[5]), subscriber_ids),nfo[7],dur[0],nfo[10])
+                log_message = '{}: {}:   System: {}); IPSC Peer: {} - {}; Subscriber: {} - {}; TS: {}; TGID: {}; Duration: {}'.format(_now,hdr[1],hdr[0],nfo[3],alias_string(int(nfo[3]), peer_ids), nfo[5], alias_string(int(nfo[5]), subscriber_ids),nfo[7],dur[0],nfo[10])
             else:
                 log_message = '{}: UNKNOWN LOG MESSAGE'.format(_now)
 


### PR DESCRIPTION
This is a simple modification to handle the event output that I was seeing, not sure if something changed in the code generating these or I just did something wrong, but it was more simple to simply handle the new format. There are certainly better ways to do this, but I was in a hurry and this is functional....

Log line examples...

```
INFO:root:BRIDGE EVENT: '(IPSC_MASTER) GROUP VOICE START: CallID: 174 PEER: 12345, SUB: 1234567, TS: 2, TGID: 310815'
INFO:root:BRIDGE EVENT: '(IPSC_MASTER) GROUP VOICE END: CallID: 175 PEER: 12345, SUB: 1234567, TS: 2, TGID: 310815 Duration: 25.33s'
```

This is the second pull request, I added spaces back into the END log line, I see why they were there for alignment purposes now.

N0PKT